### PR TITLE
Improving run_length_encode/1

### DIFF
--- a/sequential/lists/README.md
+++ b/sequential/lists/README.md
@@ -69,13 +69,13 @@ Example:
 [solution](solution/lists_exercises.erl#L77-L86)
 
 ### Run-length encoding of a list
-Implement the so-called run-length encoding data compression method. Consecutive duplicates of elements are encoded as terms [N,E] where N is the number of duplicates of the element E.
+Implement the so-called run-length encoding data compression method. Consecutive duplicates of elements are encoded as terms {N,E} where N is the number of duplicates of the element E.
 
 Example:
 
 ``` erlang
 1> lists_exercises:run_length_encode([a,a,a,a,b,c,c,a,a,d,e,e,e,e]).
-%%[[4,a],[1,b],[2,c],[2,a],[1,d],[4,e]]
+%%[{4,a},{1,b},{2,c},{2,a},{1,d},{4,e}]
 ```
 [solution](solution/lists_exercises.erl#L90-L103)
 

--- a/sequential/lists/solution/lists_exercises.erl
+++ b/sequential/lists/solution/lists_exercises.erl
@@ -90,16 +90,13 @@ rotate(L, {Dir, N}) ->
   lists:append(Left, Right).
 
 % Run-length encoding of a list
-run_length_encode([[Count, H]|[]]) ->
-  [[Count, H]];
-run_length_encode([[Count, H1], H1|T]) ->
-  run_length_encode([[Count + 1, H1]|T]);
-run_length_encode([[Count, H1], H2|T]) ->
-  [[Count, H1]|run_length_encode([[1, H2]|T])];
-run_length_encode([H|T]) ->
-  run_length_encode([[1, H]|T]);
-run_length_encode([]) ->
-  [].
+run_length_encode([], Acc) -> reverse(Acc);
+run_length_encode([H|T], [{Count, H}|AccT]) ->
+  run_length_encode(T, [{Count + 1, H}|AccT]);
+run_length_encode([H|T], Acc) -> 
+  run_length_encode(T, [{1, H}] ++ Acc).
+
+run_length_encode(L) -> run_length_encode(L, []).
 
 % Any
 list_any(F, List) ->

--- a/sequential/lists/test/lists_exercises_test.erl
+++ b/sequential/lists/test/lists_exercises_test.erl
@@ -33,7 +33,7 @@ rotate_list_left_test() ->
 
 run_length_encoding_test() ->
   List = [a, a, a, a, b, c, c, a, a, d, e, e, e, e],
-  Res = [[4, a], [1, b], [2, c], [2, a], [1, d], [4, e]],
+  Res = [{4, a}, {1, b}, {2, c}, {2, a}, {1, d}, {4, e}],
   ?assertEqual(Res, lists_exercises:run_length_encode(List)).
 
 any_is_even_test() ->


### PR DESCRIPTION
It would be better and clear to use a list of tuples as we discussed in the BeamBA meetup.
