### PR TITLE
Add missing Makefile to "installing"

### DIFF
--- a/sequential/installing/Makefile
+++ b/sequential/installing/Makefile
@@ -1,0 +1,3 @@
+.PHONY: test
+test:
+	rebar3 eunit


### PR DESCRIPTION
Instructions for `sequential/installing` tell the learner to execute `make` in order to run the tests, but no makefile was provided.

```
$> git clone https://github.com/lambdaclass/erlings.git
$> cd ~/erlings/sequential/installing
$> make
```

----------

Got this message:
```
bash-3.2$ pwd
/Users/lambda/code/erlings/sequential/installing
bash-3.2$ make
make: *** No targets specified and no makefile found.  Stop.
```

Here is a `Makefile` to fix that:

```
joaquin-lambda:installing lambda$ make
rebar3 eunit
===> Verifying dependencies...
===> Compiling installing
===> Performing EUnit tests...
.
Finished in 0.041 seconds
1 tests, 0 failures
```