### PR TITLE
fix the check we do in check-progress script

### DIFF
--- a/check-progress
+++ b/check-progress
@@ -24,7 +24,7 @@ print_failure(Folder, CurrentCount, TotalCount) ->
 
 run_make_on_folder(Folder) ->
   Output = cmd(Folder, "make"),
-  string:str(Output, "ALL TESTS PASSED") > 0.
+  string:str(Output, "tests passed.") > 0.
 
 cmd(Folder, Command) ->
   Cmd = io_lib:format("cd ~s && ~s", [Folder, Command]),

--- a/sequential/installing/Makefile
+++ b/sequential/installing/Makefile
@@ -1,3 +1,3 @@
 .PHONY: test
 test:
-	rebar3 eunit
+	rebar3 ct


### PR DESCRIPTION
I modified the check we do in `check-progress` to check if the output of the command contains the `tests passed` substring instead of `ALL TESTS PASSED` because the format of the common test output is: 
```
All <number of tests> tests passed.`
```
So it will never match as it is now. 