### PR TITLE
Fix in check-progress file and in sequential/list for exercise called last_letter

### DIFF
--- a/check-progress
+++ b/check-progress
@@ -12,6 +12,7 @@ run_tests([], _, _) ->
 run_tests([Folder | MoreFolders], CurrentCount, TotalCount) ->
   case run_make_on_folder(Folder) of
     true ->
+      io:format("~p.......ok~n", [Folder]),
       run_tests(MoreFolders, CurrentCount + 1, TotalCount);
     false ->
       print_failure(Folder, CurrentCount, TotalCount)
@@ -27,7 +28,7 @@ run_make_on_folder(Folder) ->
   string:str(Output, "tests passed.") > 0.
 
 cmd(Folder, Command) ->
-  Cmd = io_lib:format("cd ~s && ~s", [Folder, Command]),
+  Cmd = io_lib:format("~s ~s", [Command, Folder]),
   CmdString = binary_to_list(iolist_to_binary(Cmd)),
   os:cmd(CmdString).
 
@@ -35,12 +36,12 @@ exercise_folders() ->
   lists:append(
     [
      in_folder("sequential", ["installing", "hello", "hello_pattern",
-                              "lists", "filter_powers_of_2", "bank_accounts",
-                              "insert_element_at", "calculate_bmi",
-                              "maps"]),
-     in_folder("concurrent", ["ring_benchmark"]),
-     in_folder("otp", ["shortly"])
+                              "lists", "bank_accounts", "calculate_bmi", "insert_element_at",
+                              "filter_fibonacci_numbers", "maps", "regex"]),
+     in_folder("concurrent", ["calculator", "parallel_map", "priority", "ring_benchmark"]),
+     in_folder("otp", ["shopping_cart", "pool"])
      %in_folder("distributed", ["remote_fun"])
+     %in_folder("libraries", ["shortly"])
     ]).
 
 in_folder(Folder, SubFolders) ->

--- a/sequential/lists/README.md
+++ b/sequential/lists/README.md
@@ -110,16 +110,16 @@ Example:
 
 There is a game called first letter, last letter. The object of this game is for one player to say a word apple, and for the other player to say a word that begins with the last letter of the previous word, i.e. elephant.
 
-Write a function `lists:exercises:lastLetter/1` that takes a list of strings and return a list where the subsequent name starts with the final letter of the previous name. Take the first element of the list as the first word of the sequence, that names cannot be repeated.
+Write a function `lists:exercises:last_letter/1` that takes a list of strings and return a list where the subsequent name starts with the final letter of the previous name. Take the first element of the list as the first word of the sequence, that names cannot be repeated.
 
 
 Example:
 ```erlang
-1> lists_exercises:lastLetter(["turnIp","Potato","peas","OniOn","yam","letuCe","broccoli",
+1> lists_exercises:last_letter(["turnIp","Potato","peas","OniOn","yam","letuCe","broccoli",
  "asparaguS","Artichoke"]).
  %%["turnIp","Potato","OniOn"]
 
-2> lists_exercises:lastLetter([])
+2> lists_exercises:last_letter([])
 %% []
 
 ```

--- a/sequential/lists/solution/lists_exercises.erl
+++ b/sequential/lists/solution/lists_exercises.erl
@@ -112,19 +112,21 @@ anagram(List, S) ->
                 end, List).
 
 %Last Letter game
-last_letter([H|T]) -> last_letter([H|T], [H]).
+last_letter([]) -> [];
+last_letter([H|T]) -> last_letter(T, [H]).
 
 last_letter([], Acc) -> 
     lists:reverse(Acc);
-last_letter([H|T], Acc) ->
-    L = lists:nthtail(length(H)-1,H),
-    Word = find_word(L, T),
+last_letter(List, [H|T]) ->
+    Letter = lists:nthtail(length(H)-1,H),
+    Word = find_word(Letter, List),
     case Word of
         [] -> 
-            last_letter([], Acc);
+            last_letter([], [H|T]);
         _ -> 
-            NewWord= [Word|Acc],
-            last_letter(T, NewWord)       
+            NewWord = [Word, H|T],
+            NewList = lists:delete(Word, List),
+            last_letter(NewList, NewWord)    
     end.
 
 find_word(_L,[]) -> [];

--- a/sequential/lists/test/lists_exercises_test.erl
+++ b/sequential/lists/test/lists_exercises_test.erl
@@ -52,5 +52,5 @@ anagram_test() ->
 last_letter_test()->
   List = ["Afghanistan", "Albania", "Algeria", "Andorra", "Nigeria", "Norway", 
           "Yemen", "Nepal", "Morocco", "Oman", "Portugal", "Spain"],
-  Res = ["Afghanistan","Nigeria","Algeria","Andorra"],
+  Res = ["Afghanistan", "Nigeria", "Albania", "Algeria", "Andorra"],
   ?assertEqual(Res, lists_exercises:last_letter(List)).


### PR DESCRIPTION
Fixes in check-progress file, where it was calling make inside every folder, not every exercise folder have a make file, insted of calling make in root with the folders names as a parameter. Also added fix for the exercise last_letter in sequential/lists wich wasn't giving the proper result